### PR TITLE
Make it work for true on Linux with OpenGL 3.3 +

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,11 @@ FLAGS_ALL = -framework SDL2 -framework OPENGL
 endif
 
 ifeq ($(UNAME), Linux)
-CFLAGS += -D__LINUX__ -DGL_GLEXT_PROTOTYPES -DGL3_PROTOTYPES=1
-FLAGS_ALL = -lGL `sdl2-config --cflags --libs`
+# comment this line if your machine is not OpenGL 3.3. capable (e.g. 3.0 only)
+#OPENGL_CAP = -DOpenGL33_OK
+
+CFLAGS += -DLinux $(OPENGL_CAP)
+FLAGS_ALL = -lGL -lGLEW `sdl2-config --cflags --libs`
 endif
 
 all: $(OBJECTS)

--- a/include/App.hpp
+++ b/include/App.hpp
@@ -5,7 +5,14 @@
 #include <OpenGL/gl3.h>
 #endif
 
-#ifdef __LINUX__
+#if defined (Linux)
+#ifndef GL_GLEXT_PROTOTYPES
+#define GL_GLEXT_PROTOTYPES 1
+#endif
+#include <iostream>
+#if defined (OpenGL33_OK )
+#include <GL/glew.h>
+#endif
 #include <GL/gl.h>
 #endif
 
@@ -15,6 +22,12 @@
 #include <glm/gtc/matrix_transform.hpp>
 
 #define AppNull (App*)0
+
+#if defined( Linux ) && defined (OpenGL33_OK )
+#ifndef GL3_PROTOTYPES
+#define GL3_PROTOTYPES 1
+#endif
+#endif /* Linux and OpenGL33_OK */
 
 typedef void (*DrawCallback)(glm::mat4 transform);
 

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -9,7 +9,15 @@ App::App(const char* title, int width, int height, bool oldOpenGL)
 		SDL_Log("Unable to initialize SDL: %s", SDL_GetError());
 		return;
 	}
+#if defined( Linux ) && defined( OpenGL33_OK )
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+        SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
+        SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
+        SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
 
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
+#else
 	if(oldOpenGL)
 	{
 		//OpenGL compatibility profile - deprecated functions are allowed
@@ -20,7 +28,7 @@ App::App(const char* title, int width, int height, bool oldOpenGL)
 		//OpenGL core profile - deprecated functions are disabled
 		SDL_GL_SetAttribute (SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
 	}
-
+#endif
 	this->window = SDL_CreateWindow(title,SDL_WINDOWPOS_CENTERED,SDL_WINDOWPOS_CENTERED,width,height,SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
 	if(!this->window)
 	{
@@ -29,6 +37,12 @@ App::App(const char* title, int width, int height, bool oldOpenGL)
 	}
 
 	this->context = SDL_GL_CreateContext(window);
+
+#if defined( Linux ) && defined( OpenGL33_OK )
+        glewExperimental = GL_TRUE;
+        glewInit();
+#endif
+
 	if(!context)
 	{
 		SDL_Log("Unable to create OPENGL context: %s", SDL_GetError());
@@ -38,6 +52,15 @@ App::App(const char* title, int width, int height, bool oldOpenGL)
 	this->perspectiveAspect = (1.0f*width)/height;
 	this->lookAt(glm::vec3(0.0f,0.0f,10.0f),glm::vec3(0.0f,0.0f,0.0f),glm::vec3(0.0f,1.0f,0.0f));
 	this->perspective(glm::radians(45.0f),0.1f,100.0f);
+
+#ifdef Linux
+        std::cout << "OpenGL version: " << glGetString(GL_VERSION) << std::endl;
+        std::cout << "GLSL version: " 
+                  << glGetString(GL_SHADING_LANGUAGE_VERSION) << std::endl;
+        std::cout << "Vendor: " << glGetString(GL_VENDOR) << std::endl;
+        std::cout << "Renderer: " << glGetString(GL_RENDERER) << std::endl;
+#endif
+
 	glEnable(GL_DEPTH_TEST);
 	this->canRun = true;
 


### PR DESCRIPTION
Hello,

I tested your code, and there was no rendering. In this PR, you'll find some changes, and it seems to work well. 

How it works: 

- in the Makefile, if  `OpenGL33_OK` is defined -supposing your machine got a true OpenGL 3.3+ engine, glew and everything correctly installed-, the build is ok, and the rendering is ok. I got 4 cubes rotating + the mouse coordinate on the terminal (am i correct ?)

Output is (e.g. for me):
````
./Application
OpenGL version: 4.5 (Core Profile) Mesa 18.0.5
GLSL version: 4.50
Vendor: Intel Open Source Technology Center
Renderer: Mesa DRI Intel(R) UHD Graphics 620 (Kabylake GT2) 
INFO: Shader vertexAndColorShader carregado com sucesso
INFO: Mouse Position 0x97
INFO: Mouse Position 11x92
INFO: Mouse Position 25x88
INFO: Mouse Position 37x86
INFO: Mouse Position 45x85
INFO: Mouse Position 51x85
( ... )
````

- when the line `OPENGL_CAP = -DOpenGL33_OK`  is commented (with a ````#```` symbol), the build can end (if I'm not wrong, excepted the glGetString(), this is your current code)but the shaders won't compile and the window will remain green and empty at the end ;-) .


````
 $ ./Application
OpenGL version: 3.0 Mesa 18.0.5
GLSL version: 1.30
Vendor: Intel Open Source Technology Center
Renderer: Mesa DRI Intel(R) UHD Graphics 620 (Kabylake GT2) 
INFO: Unable to compile shader: 0:1(10): error: GLSL 4.00 is not supported. Supported versions are: 1.10, 1.20, 1.30, 1.00 ES, 3.00 ES, 3.10 ES, and 3.20 ES

````
The code is under the MIT license, and do what you want with it ;-) (don't hesitate to ask me if you need another license )

Cheers,
ericb


 